### PR TITLE
Add basic nav pages

### DIFF
--- a/src/Header/Component.client.tsx
+++ b/src/Header/Component.client.tsx
@@ -4,16 +4,10 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
 
-import type { Header } from '@/payload-types'
-
 import { Logo } from '@/components/Logo/Logo'
 import { HeaderNav } from './Nav'
 
-interface HeaderClientProps {
-  data: Header
-}
-
-export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
+export const HeaderClient: React.FC = () => {
   /* Storing the value in a useState to avoid hydration errors */
   const [theme, setTheme] = useState<string | null>(null)
   const { headerTheme, setHeaderTheme } = useHeaderTheme()
@@ -33,9 +27,9 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ data }) => {
     <header className="container relative z-20   " {...(theme ? { 'data-theme': theme } : {})}>
       <div className="py-8 flex justify-between">
         <Link href="/">
-          <Logo loading="eager" priority="high" className="invert" />
+          <Logo className="invert" />
         </Link>
-        <HeaderNav data={data} />
+        <HeaderNav />
       </div>
     </header>
   )

--- a/src/Header/Component.tsx
+++ b/src/Header/Component.tsx
@@ -1,11 +1,6 @@
 import { HeaderClient } from './Component.client'
-import { getCachedGlobal } from '@/utilities/getGlobals'
 import React from 'react'
 
-import type { Header } from '@/payload-types'
-
-export async function Header() {
-  const headerData: Header = await getCachedGlobal('header', 1)()
-
-  return <HeaderClient data={headerData} />
+export function Header() {
+  return <HeaderClient />
 }

--- a/src/Header/Nav/index.tsx
+++ b/src/Header/Nav/index.tsx
@@ -1,25 +1,24 @@
 'use client'
 
 import React from 'react'
-
-import type { Header as HeaderType } from '@/payload-types'
-
-import { CMSLink } from '@/components/Link'
 import Link from 'next/link'
-import { SearchIcon } from 'lucide-react'
 
-export const HeaderNav: React.FC<{ data: HeaderType }> = ({ data }) => {
-  const navItems = data?.navItems || []
+const NAV_ITEMS = [
+  { href: '/inici', label: 'Inici' },
+  { href: '/qui-soc', label: 'Qui soc?' },
+  { href: '/serveis', label: 'Serveis' },
+  { href: '/productes', label: 'Productes' },
+  { href: '/contacte', label: 'Contacte' },
+]
 
+export const HeaderNav: React.FC = () => {
   return (
     <nav className="flex gap-3 items-center">
-      {navItems.map(({ link }, i) => {
-        return <CMSLink key={i} {...link} appearance="link" />
-      })}
-      <Link href="/search">
-        <span className="sr-only">Search</span>
-        <SearchIcon className="w-5 text-primary" />
-      </Link>
+      {NAV_ITEMS.map((item) => (
+        <Link key={item.href} href={item.href} className="hover:underline">
+          {item.label}
+        </Link>
+      ))}
     </nav>
   )
 }

--- a/src/app/(frontend)/contacte/page.tsx
+++ b/src/app/(frontend)/contacte/page.tsx
@@ -1,0 +1,3 @@
+export default function ContactePage() {
+  return <h1>Contacte works!</h1>
+}

--- a/src/app/(frontend)/inici/page.tsx
+++ b/src/app/(frontend)/inici/page.tsx
@@ -1,0 +1,3 @@
+export default function IniciPage() {
+  return <h1>Inici works!</h1>
+}

--- a/src/app/(frontend)/productes/page.tsx
+++ b/src/app/(frontend)/productes/page.tsx
@@ -1,0 +1,3 @@
+export default function ProductesPage() {
+  return <h1>Productes works!</h1>
+}

--- a/src/app/(frontend)/qui-soc/page.tsx
+++ b/src/app/(frontend)/qui-soc/page.tsx
@@ -1,0 +1,3 @@
+export default function QuiSocPage() {
+  return <h1>Qui soc? works!</h1>
+}

--- a/src/app/(frontend)/serveis/page.tsx
+++ b/src/app/(frontend)/serveis/page.tsx
@@ -1,0 +1,3 @@
+export default function ServeisPage() {
+  return <h1>Serveis works!</h1>
+}

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -3,27 +3,8 @@ import React from 'react'
 
 interface Props {
   className?: string
-  loading?: 'lazy' | 'eager'
-  priority?: 'auto' | 'high' | 'low'
 }
 
-export const Logo = (props: Props) => {
-  const { loading: loadingFromProps, priority: priorityFromProps, className } = props
-
-  const loading = loadingFromProps || 'lazy'
-  const priority = priorityFromProps || 'low'
-
-  return (
-    /* eslint-disable @next/next/no-img-element */
-    <img
-      alt="Payload Logo"
-      width={193}
-      height={34}
-      loading={loading}
-      fetchPriority={priority}
-      decoding="async"
-      className={clsx('max-w-[9.375rem] w-full h-[34px]', className)}
-      src="https://raw.githubusercontent.com/payloadcms/payload/main/packages/ui/src/assets/payload-logo-light.svg"
-    />
-  )
+export const Logo = ({ className }: Props) => {
+  return <span className={clsx('text-xl font-bold', className)}>ABSENCIA</span>
 }


### PR DESCRIPTION
## Summary
- simplify header to remove CMS banner and search icon
- add a basic nav with five pages
- swap payload logo for simple text
- stub out pages for each nav link

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68483a9a61208331b2f2fa2016517b45