### PR TITLE
Make hero reusable block

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Create unique page layouts for any type of content using a powerful layout build
 
 Each block is fully designed and built into the front-end website that comes with this template. See [Website](#website) for more details.
 
+The **Hero** block can be placed anywhere within a page's layout. Configure the
+image, title and subtitle in the CMS and then drag the block to the desired
+position when building a page.
+
 ## Lexical editor
 
 A deep editorial experience that allows complete freedom to focus just on writing content without breaking out of the flow with support for Payload blocks, media, links and other features provided out of the box. See [Lexical](https://payloadcms.com/docs/rich-text/overview) docs.

--- a/src/heros/HighImpact/index.tsx
+++ b/src/heros/HighImpact/index.tsx
@@ -8,7 +8,13 @@ import { CMSLink } from '@/components/Link'
 import { Media } from '@/components/Media'
 import RichText from '@/components/RichText'
 
-export const HighImpactHero: React.FC<Page['hero']> = ({ links, media, richText }) => {
+export const HighImpactHero: React.FC<Page['hero']> = ({
+  links,
+  media,
+  richText,
+  title,
+  subtitle,
+}) => {
   const { setHeaderTheme } = useHeaderTheme()
 
   useEffect(() => {
@@ -22,6 +28,8 @@ export const HighImpactHero: React.FC<Page['hero']> = ({ links, media, richText 
     >
       <div className="container mb-8 z-10 relative flex items-center justify-center">
         <div className="max-w-[36.5rem] md:text-center">
+          {title && <h1 className="mb-4 text-4xl md:text-5xl">{title}</h1>}
+          {subtitle && <p className="mb-4 text-lg md:text-xl">{subtitle}</p>}
           {richText && <RichText className="mb-6" data={richText} enableGutter={false} />}
           {Array.isArray(links) && links.length > 0 && (
             <ul className="flex md:justify-center gap-4">

--- a/src/heros/LowImpact/index.tsx
+++ b/src/heros/LowImpact/index.tsx
@@ -14,10 +14,17 @@ type LowImpactHeroType =
       richText?: Page['hero']['richText']
     })
 
-export const LowImpactHero: React.FC<LowImpactHeroType> = ({ children, richText }) => {
+export const LowImpactHero: React.FC<LowImpactHeroType> = ({
+  children,
+  richText,
+  title,
+  subtitle,
+}) => {
   return (
     <div className="container mt-16">
       <div className="max-w-[48rem]">
+        {title && <h1 className="mb-4 text-3xl md:text-5xl">{title}</h1>}
+        {subtitle && <p className="mb-4 text-lg md:text-xl">{subtitle}</p>}
         {children || (richText && <RichText data={richText} enableGutter={false} />)}
       </div>
     </div>

--- a/src/heros/MediumImpact/index.tsx
+++ b/src/heros/MediumImpact/index.tsx
@@ -6,10 +6,18 @@ import { CMSLink } from '@/components/Link'
 import { Media } from '@/components/Media'
 import RichText from '@/components/RichText'
 
-export const MediumImpactHero: React.FC<Page['hero']> = ({ links, media, richText }) => {
+export const MediumImpactHero: React.FC<Page['hero']> = ({
+  links,
+  media,
+  richText,
+  title,
+  subtitle,
+}) => {
   return (
     <div className="">
       <div className="container mb-8">
+        {title && <h1 className="mb-4 text-3xl md:text-5xl">{title}</h1>}
+        {subtitle && <p className="mb-4 text-lg md:text-xl">{subtitle}</p>}
         {richText && <RichText className="mb-6" data={richText} enableGutter={false} />}
 
         {Array.isArray(links) && links.length > 0 && (

--- a/src/heros/config.ts
+++ b/src/heros/config.ts
@@ -39,6 +39,16 @@ export const hero: Field = {
       required: true,
     },
     {
+      name: 'title',
+      label: 'Title',
+      type: 'text',
+    },
+    {
+      name: 'subtitle',
+      label: 'Subtitle',
+      type: 'text',
+    },
+    {
       name: 'richText',
       type: 'richText',
       editor: lexicalEditor({

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -150,6 +150,8 @@ export interface Page {
   title: string;
   hero: {
     type: 'none' | 'highImpact' | 'mediumImpact' | 'lowImpact';
+    title?: string | null;
+    subtitle?: string | null;
     richText?: {
       root: {
         type: string;
@@ -741,6 +743,8 @@ export interface Form {
  */
 export interface HeroBlock {
   type: 'none' | 'highImpact' | 'mediumImpact' | 'lowImpact';
+  title?: string | null;
+  subtitle?: string | null;
   richText?: {
     root: {
       type: string;
@@ -1077,6 +1081,8 @@ export interface PagesSelect<T extends boolean = true> {
     | T
     | {
         type?: T;
+        title?: T;
+        subtitle?: T;
         richText?: T;
         links?:
           | T
@@ -1210,6 +1216,8 @@ export interface FormBlockSelect<T extends boolean = true> {
  */
 export interface HeroBlockSelect<T extends boolean = true> {
   type?: T;
+  title?: T;
+  subtitle?: T;
   richText?: T;
   links?:
     | T


### PR DESCRIPTION
## Summary
- allow hero block to store title and subtitle
- expose hero block placement and configuration in README
- display title and subtitle in hero components
- regenerate Payload types

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68485197c5988331ac3192f83384d248