### PR TITLE
Add ContactForm block configurable via CMS

### DIFF
--- a/src/app/(frontend)/contacte/page.tsx
+++ b/src/app/(frontend)/contacte/page.tsx
@@ -1,3 +1,66 @@
-export default function ContactePage() {
-  return <h1>Contacte works!</h1>
+import type { Metadata } from 'next'
+
+import { PayloadRedirects } from '@/components/PayloadRedirects'
+import configPromise from '@payload-config'
+import { getPayload, type RequiredDataFromCollectionSlug } from 'payload'
+import { draftMode } from 'next/headers'
+import React, { cache } from 'react'
+
+import { RenderBlocks } from '@/blocks/RenderBlocks'
+import { RenderHero } from '@/heros/RenderHero'
+import { generateMeta } from '@/utilities/generateMeta'
+import PageClient from '../[slug]/page.client'
+import { LivePreviewListener } from '@/components/LivePreviewListener'
+
+export const dynamic = 'force-static'
+export const revalidate = 600
+
+export default async function ContactPage() {
+  const { isEnabled: draft } = await draftMode()
+  const slug = 'contact'
+  const url = '/' + slug
+
+  const page = await queryPageBySlug({ slug })
+
+  if (!page) {
+    return <PayloadRedirects url={url} />
+  }
+
+  const { hero, layout } = page
+
+  return (
+    <article className="pt-16 pb-24">
+      <PageClient />
+      <PayloadRedirects disableNotFound url={url} />
+      {draft && <LivePreviewListener />}
+      <RenderHero {...hero} />
+      <RenderBlocks blocks={layout} />
+    </article>
+  )
 }
+
+export async function generateMetadata(): Promise<Metadata> {
+  const page = await queryPageBySlug({ slug: 'contact' })
+  return generateMeta({ doc: page })
+}
+
+const queryPageBySlug = cache(async ({ slug }: { slug: string }) => {
+  const { isEnabled: draft } = await draftMode()
+
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'pages',
+    draft,
+    limit: 1,
+    pagination: false,
+    overrideAccess: draft,
+    where: {
+      slug: {
+        equals: slug,
+      },
+    },
+  })
+
+  return result.docs?.[0] as RequiredDataFromCollectionSlug<'pages'> | null
+})

--- a/src/blocks/ContactFormBlock/Component.tsx
+++ b/src/blocks/ContactFormBlock/Component.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { ContactForm } from '@/components/ContactForm'
+
+// Minimal props definition to avoid depending on generated types
+export interface BlockProps {
+  fields: Parameters<typeof ContactForm>[0]['fields']
+  submitLabel?: string
+}
+
+export const ContactFormBlock: React.FC<BlockProps> = ({ fields, submitLabel }) => {
+  return (
+    <div className="container">
+      <ContactForm fields={fields} submitLabel={submitLabel} />
+    </div>
+  )
+}
+

--- a/src/blocks/ContactFormBlock/config.ts
+++ b/src/blocks/ContactFormBlock/config.ts
@@ -1,0 +1,65 @@
+import type { Block } from 'payload'
+
+export const ContactFormBlock: Block = {
+  slug: 'contactForm',
+  interfaceName: 'ContactFormBlock',
+  fields: [
+    {
+      name: 'fields',
+      type: 'array',
+      required: true,
+      fields: [
+        {
+          name: 'name',
+          label: 'Name',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'label',
+          label: 'Label',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'type',
+          label: 'Type',
+          type: 'select',
+          defaultValue: 'text',
+          options: [
+            { label: 'Text', value: 'text' },
+            { label: 'Email', value: 'email' },
+            { label: 'Phone', value: 'phone' },
+            { label: 'Textarea', value: 'textarea' },
+          ],
+        },
+        {
+          name: 'placeholder',
+          type: 'text',
+          label: 'Placeholder',
+        },
+        {
+          name: 'icon',
+          type: 'text',
+          label: 'Icon class',
+        },
+        {
+          name: 'required',
+          type: 'checkbox',
+          label: 'Required',
+        },
+      ],
+    },
+    {
+      name: 'submitLabel',
+      type: 'text',
+      defaultValue: 'Send',
+      required: true,
+    },
+  ],
+  labels: {
+    singular: 'Contact Form',
+    plural: 'Contact Forms',
+  },
+}
+

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -6,6 +6,7 @@ import { ArchiveBlock } from '@/blocks/ArchiveBlock/Component'
 import { CallToActionBlock } from '@/blocks/CallToAction/Component'
 import { ContentBlock } from '@/blocks/Content/Component'
 import { FormBlock } from '@/blocks/Form/Component'
+import { ContactFormBlock } from '@/blocks/ContactFormBlock/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { HeroBlock } from '@/blocks/Hero/Component'
 import { ImageTextSectionBlock } from '@/blocks/ImageTextSection/Component'
@@ -15,6 +16,7 @@ const blockComponents = {
   content: ContentBlock,
   cta: CallToActionBlock,
   formBlock: FormBlock,
+  contactForm: ContactFormBlock,
   mediaBlock: MediaBlock,
   hero: HeroBlock,
   imageTextSection: ImageTextSectionBlock,

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -6,6 +6,7 @@ import { Archive } from '../../blocks/ArchiveBlock/config'
 import { CallToAction } from '../../blocks/CallToAction/config'
 import { Content } from '../../blocks/Content/config'
 import { FormBlock } from '../../blocks/Form/config'
+import { ContactFormBlock } from '../../blocks/ContactFormBlock/config'
 import { MediaBlock } from '../../blocks/MediaBlock/config'
 import { Hero } from '../../blocks/Hero/config'
 import { ImageTextSection } from '../../blocks/ImageTextSection/config'
@@ -83,6 +84,7 @@ export const Pages: CollectionConfig<'pages'> = {
                 MediaBlock,
                 Archive,
                 FormBlock,
+                ContactFormBlock,
                 Hero,
                 ImageTextSection,
               ],

--- a/src/components/ContactForm/index.tsx
+++ b/src/components/ContactForm/index.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import React from 'react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/utilities/ui'
+
+export type FieldType = 'text' | 'email' | 'phone' | 'textarea'
+
+export interface FieldOption {
+  name: string
+  type: FieldType
+  label: string
+  placeholder?: string
+  icon?: string
+  required?: boolean
+}
+
+export interface ContactFormProps {
+  fields?: FieldOption[]
+  submitLabel?: string
+  onSubmit?: (values: Record<string, string>) => void
+  className?: string
+}
+
+const defaultFields: FieldOption[] = [
+  { name: 'name', type: 'text', label: 'Name', icon: 'pi pi-user', required: true },
+  { name: 'email', type: 'email', label: 'Email', icon: 'pi pi-envelope', required: true },
+  { name: 'message', type: 'textarea', label: 'Message', icon: 'pi pi-comment', required: true },
+]
+
+const defaultIcons: Record<FieldType, string> = {
+  text: 'pi pi-user',
+  email: 'pi pi-envelope',
+  phone: 'pi pi-phone',
+  textarea: 'pi pi-comment',
+}
+
+export const ContactForm: React.FC<ContactFormProps> = ({
+  fields = defaultFields,
+  submitLabel = 'Send',
+  onSubmit,
+  className,
+}) => {
+  const initialState = React.useMemo(() => {
+    return fields.reduce<Record<string, string>>((acc, field) => {
+      acc[field.name] = ''
+      return acc
+    }, {})
+  }, [fields])
+
+  const [values, setValues] = React.useState<Record<string, string>>(initialState)
+
+  const handleChange =
+    (name: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setValues((prev) => ({ ...prev, [name]: e.target.value }))
+    }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (onSubmit) onSubmit(values)
+  }
+
+  return (
+    <form className={cn('space-y-4', className)} onSubmit={handleSubmit}>
+      {fields.map((field) => {
+        const id = `contact-${field.name}`
+        const iconClass = field.icon || defaultIcons[field.type]
+        const InputComponent = field.type === 'textarea' ? Textarea : Input
+        const typeAttr = field.type === 'email' ? 'email' : field.type === 'phone' ? 'tel' : 'text'
+
+        return (
+          <div key={field.name} className="space-y-1">
+            <Label htmlFor={id} className="flex items-center gap-2">
+              {iconClass && <i className={cn(iconClass, 'text-muted-foreground')} />}
+              {field.label}
+              {field.required && <span className="text-destructive">*</span>}
+            </Label>
+            <InputComponent
+              id={id}
+              onChange={handleChange(field.name)}
+              placeholder={field.placeholder}
+              required={field.required}
+              type={field.type === 'textarea' ? undefined : typeAttr}
+              value={values[field.name]}
+            />
+          </div>
+        )
+      })}
+      <Button type="submit">{submitLabel}</Button>
+    </form>
+  )
+}
+
+export default ContactForm


### PR DESCRIPTION
## Summary
- implement a CMS-driven `ContactFormBlock` with configurable fields and icons
- expose new block in `RenderBlocks` and `Pages` collection
- allow `/contacte` page to load the `contact` page content from Payload
- refactor `ContactForm` component to accept icon class names

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Next.js build worker exited with code: 1)*

------
https://chatgpt.com/codex/tasks/task_e_684852cbed748331ac89607bad43143f