### PR TITLE
Add clown-themed style and scroll animations

### DIFF
--- a/src/app/(frontend)/globals.css
+++ b/src/app/(frontend)/globals.css
@@ -14,25 +14,25 @@
   }
 
   :root {
-    --background: 50 100% 97%;
+    --background: 60 100% 96%;
     --foreground: 222.2 84% 4.9%;
 
-    --card: 48 100% 98%;
+    --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
 
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
 
-    --primary: 0 84% 60%;
+    --primary: 0 90% 56%;
     --primary-foreground: 210 40% 98%;
 
-    --secondary: 214 84% 56%;
+    --secondary: 220 100% 60%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 0 0% 98%;
+    --muted: 50 100% 90%;
     --muted-foreground: 215.4 16.3% 46.9%;
 
-    --accent: 318 82% 63%;
+    --accent: 120 80% 65%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 84.2% 60.2%;
@@ -50,7 +50,7 @@
   }
 
   [data-theme='dark'] {
-    --background: 0 0% 0%;
+    --background: 240 5% 10%;
     --foreground: 210 40% 98%;
 
     --card: 0 0% 4%;
@@ -59,16 +59,16 @@
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
 
-    --primary: 210 40% 98%;
+    --primary: 0 90% 60%;
     --primary-foreground: 222.2 47.4% 11.2%;
 
-    --secondary: 217.2 32.6% 17.5%;
+    --secondary: 220 100% 70%;
     --secondary-foreground: 210 40% 98%;
 
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
 
-    --accent: 217.2 32.6% 17.5%;
+    --accent: 120 80% 70%;
     --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
@@ -100,4 +100,19 @@ html {
 html[data-theme='dark'],
 html[data-theme='light'] {
   opacity: initial;
+}
+
+@keyframes float-up {
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-100vh);
+    opacity: 0;
+  }
+}
+
+.balloon {
+  animation: float-up 4s linear forwards;
 }

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -12,6 +12,7 @@ import { Header } from '@/Header/Component'
 import { Providers } from '@/providers'
 import { mergeOpenGraph } from '@/utilities/mergeOpenGraph'
 import { draftMode } from 'next/headers'
+import Balloons from '@/components/Balloons'
 
 import './globals.css'
 import { getServerSideURL } from '@/utilities/getURL'
@@ -37,6 +38,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <link href="/favicon.svg" rel="icon" type="image/svg+xml" />
       </head>
       <body>
+        <Balloons />
         <Providers>
           <AdminBar
             adminBarProps={{

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -9,6 +9,7 @@ import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { HeroBlock } from '@/blocks/Hero/Component'
 import { ImageTextSectionBlock } from '@/blocks/ImageTextSection/Component'
 import ImageGridHeroBlock from '@/blocks/ImageGridHero/Component'
+import { AnimatedBlock } from '@/components/AnimatedBlock'
 
 const blockComponents = {
   content: ContentBlock,
@@ -38,9 +39,9 @@ export const RenderBlocks: React.FC<{
 
             if (Block) {
               return (
-                <div className="my-16" key={index}>
+                <AnimatedBlock className="my-16" key={index}>
                   <Block {...block} disableInnerContainer />
-                </div>
+                </AnimatedBlock>
               )
             }
           }

--- a/src/components/AnimatedBlock.tsx
+++ b/src/components/AnimatedBlock.tsx
@@ -1,0 +1,23 @@
+'use client'
+import React from 'react'
+import { cn } from '@/utilities/ui'
+import { useScrollReveal } from '@/hooks/useScrollReveal'
+
+export const AnimatedBlock: React.FC<{
+  className?: string
+  children: React.ReactNode
+}> = ({ className, children }) => {
+  const { ref, inView } = useScrollReveal<HTMLDivElement>()
+  return (
+    <div
+      ref={ref}
+      data-in-view={inView}
+      className={cn(
+        'opacity-0 data-[in-view=true]:opacity-100 data-[in-view=true]:animate-in data-[in-view=true]:fade-in data-[in-view=true]:slide-in-from-bottom-6',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/src/components/Balloons/index.tsx
+++ b/src/components/Balloons/index.tsx
@@ -1,0 +1,47 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+
+const IMAGES = ['/balloons/balloon1.png', '/balloons/balloon2.png', '/balloons/balloon3.png']
+
+let counter = 0
+
+interface Balloon {
+  id: number
+  left: number
+  img: string
+}
+
+export const Balloons: React.FC = () => {
+  const [balloons, setBalloons] = useState<Balloon[]>([])
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setBalloons((b) => [
+        ...b,
+        {
+          id: counter++,
+          left: Math.random() * 80,
+          img: IMAGES[Math.floor(Math.random() * IMAGES.length)],
+        },
+      ])
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
+      {balloons.map((balloon) => (
+        <img
+          key={balloon.id}
+          src={balloon.img}
+          className="balloon absolute bottom-0 w-12 h-12"
+          style={{ left: `${balloon.left}%` }}
+          onAnimationEnd={() => setBalloons((b) => b.filter((item) => item.id !== balloon.id))}
+        />
+      ))}
+    </div>
+  )
+}
+export default Balloons

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,31 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+
+export function useScrollReveal<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null)
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setInView(true)
+            observer.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.1 },
+    )
+
+    observer.observe(node)
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  return { ref, inView }
+}


### PR DESCRIPTION
## Summary
- brighten default color palette to match a clown company
- animate blocks on scroll
- add floating balloon animations when scrolling
- wire balloons globally in the layout

## Testing
- `npm run lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498e0f40588331b0ae42f9c8468008