### PR TITLE
Add StepFlowImage block

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -11,6 +11,7 @@ import { ImageTextSectionBlock } from '@/blocks/ImageTextSection/Component'
 import ImageGridHeroBlock from '@/blocks/ImageGridHero/Component'
 import ImgForm from '@/blocks/ImgForm/Component.client'
 import StepFlowBlock from './StepFlowBlock/Component'
+import StepFlowImageBlock from './StepFlowImageBlock/Component'
 
 const blockComponents = {
   content: ContentBlock,
@@ -22,6 +23,7 @@ const blockComponents = {
   imageGridHero: ImageGridHeroBlock,
   imgForm: ImgForm,
   stepFlow: StepFlowBlock,
+  stepFlowImage: StepFlowImageBlock,
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/blocks/StepFlowImageBlock/Component.tsx
+++ b/src/blocks/StepFlowImageBlock/Component.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import React from 'react'
+import { Media } from '@/components/Media'
+
+export interface StepFlowImageBlockProps {
+  title?: string
+  steps: Array<{
+    title: string
+    description: string
+  }>
+  image: any
+}
+
+export const StepFlowImageBlock: React.FC<StepFlowImageBlockProps> = ({
+  title,
+  steps,
+  image,
+}) => {
+  if (!steps || steps.length !== 3) return null
+
+  return (
+    <section className="container font-poppins py-16 mt-32">
+      {title && <h2 className="text-3xl font-bold text-center mb-12">{title}</h2>}
+
+      <div className="flex flex-col md:flex-row items-center gap-12">
+        <div className="flex-1">
+          <div className="relative flex flex-col md:flex-row md:justify-between md:items-start">
+            {steps.map((step, idx) => (
+              <React.Fragment key={idx}>
+                <div className="relative flex flex-col items-center text-center mb-12 md:mb-0 md:flex-1 z-10">
+                  <div className="flex items-center justify-center w-12 h-12 rounded-full bg-[#c63a77] text-white text-lg font-bold mb-4">
+                    {idx + 1}
+                  </div>
+                  <h3 className="font-semibold mb-2">{step.title}</h3>
+                  <p className="text-gray-500 max-w-xs">{step.description}</p>
+                </div>
+                {idx < steps.length - 1 && (
+                  <div className="hidden md:flex items-center mt-6 md:mb-0">
+                    <div className="w-32 h-px border-t-2 border-dashed border-gray-400 mx-2"></div>
+                  </div>
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+
+        {image && (
+          <div className="w-full md:w-1/3 aspect-[4/3] relative rounded-xl overflow-hidden shadow-xl">
+            <Media resource={image} fill imgClassName="object-cover object-center" />
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default StepFlowImageBlock

--- a/src/blocks/StepFlowImageBlock/config.ts
+++ b/src/blocks/StepFlowImageBlock/config.ts
@@ -1,0 +1,47 @@
+import type { Block } from 'payload'
+
+export const StepFlowImageBlock: Block = {
+  slug: 'stepFlowImage',
+  interfaceName: 'StepFlowImageBlock',
+  fields: [
+    {
+      name: 'title',
+      label: 'Título principal',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'steps',
+      label: 'Pasos',
+      type: 'array',
+      minRows: 3,
+      maxRows: 3,
+      required: true,
+      fields: [
+        {
+          name: 'title',
+          label: 'Título del paso',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'description',
+          label: 'Descripción',
+          type: 'textarea',
+          required: true,
+        },
+      ],
+    },
+    {
+      name: 'image',
+      label: 'Imagen',
+      type: 'upload',
+      relationTo: 'media',
+      required: true,
+    },
+  ],
+  labels: {
+    singular: 'Step Flow con Imagen',
+    plural: 'Step Flows con Imagen',
+  },
+}

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -10,6 +10,7 @@ import { Hero } from '../../blocks/Hero/config'
 import { ImageTextSection } from '../../blocks/ImageTextSection/config'
 import { ImageGridHero } from '../../blocks/ImageGridHero/config'
 import { ImgFormBlock } from '../../blocks/ImgForm/config'
+import { StepFlowImageBlock } from '../../blocks/StepFlowImageBlock/config'
 import { slugField } from '@/fields/slug'
 import { populatePublishedAt } from '../../hooks/populatePublishedAt'
 import { generatePreviewPath } from '../../utilities/generatePreviewPath'
@@ -84,6 +85,7 @@ export const Pages: CollectionConfig<'pages'> = {
                 ImageGridHero,
                 ImgFormBlock,
                 StepFlowBlock,
+                StepFlowImageBlock,
               ],
               required: true,
               admin: {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -186,6 +186,7 @@ export interface Page {
         blockType: 'imgForm';
       }
     | StepFlowBlock
+    | StepFlowImageBlock
   )[];
   meta?: {
     title?: string | null;
@@ -765,6 +766,22 @@ export interface StepFlowBlock {
   blockType: 'stepFlow';
 }
 /**
+ * This interface was referenced by `Config`'s JSON-Schema`
+ * via the `definition` "StepFlowImageBlock".
+ */
+export interface StepFlowImageBlock {
+  title?: string | null;
+  steps: {
+    title: string;
+    description: string;
+    id?: string | null;
+  }[];
+  image: number | Media;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'stepFlowImage';
+}
+/**
  * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
@@ -1054,6 +1071,7 @@ export interface PagesSelect<T extends boolean = true> {
               blockName?: T;
             };
         stepFlow?: T | StepFlowBlockSelect<T>;
+        stepFlowImage?: T | StepFlowImageBlockSelect<T>;
       };
   meta?:
     | T
@@ -1213,6 +1231,23 @@ export interface StepFlowBlockSelect<T extends boolean = true> {
         description?: T;
         id?: T;
       };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema`.
+ * via the `definition` "StepFlowImageBlock_select".
+ */
+export interface StepFlowImageBlockSelect<T extends boolean = true> {
+  title?: T;
+  steps?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+        id?: T;
+      };
+  image?: T;
   id?: T;
   blockName?: T;
 }


### PR DESCRIPTION
## Summary
- add **StepFlowImageBlock** with 3 steps and an image
- render `stepFlowImage` in pages and block renderer
- update generated types with new block

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684ff6d2410c833180177b5622479b52