### PR TITLE
Add SpectacleCarousel block

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -11,6 +11,7 @@ import { ImageTextSectionBlock } from '@/blocks/ImageTextSection/Component'
 import ImageGridHeroBlock from '@/blocks/ImageGridHero/Component'
 import ImgForm from '@/blocks/ImgForm/Component.client'
 import StepFlowBlock from './StepFlowBlock/Component'
+import SpectacleCarouselBlock from '@/blocks/SpectacleCarousel/Component'
 
 const blockComponents = {
   content: ContentBlock,
@@ -21,6 +22,7 @@ const blockComponents = {
   imageTextSection: ImageTextSectionBlock,
   imageGridHero: ImageGridHeroBlock,
   imgForm: ImgForm,
+  spectacleCarousel: SpectacleCarouselBlock,
   stepFlow: StepFlowBlock,
 }
 

--- a/src/blocks/SpectacleCarousel/Component.tsx
+++ b/src/blocks/SpectacleCarousel/Component.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import React from 'react'
+import { Media } from '@/components/Media'
+import type { SpectacleCarouselBlock as BlockProps } from '@/payload-types'
+import { cn } from '@/utilities/ui'
+
+export const SpectacleCarouselBlock: React.FC<BlockProps & { className?: string }> = ({ title, slides, className }) => {
+  if (!slides || slides.length === 0) return null
+
+  return (
+    <section className={cn('my-16', className)}>
+      {title && <h2 className="text-3xl font-bold text-center mb-8">{title}</h2>}
+      <div className="overflow-x-auto">
+        <div className="flex gap-4">
+          {slides.map((slide, idx) => (
+            <div key={idx} className="min-w-[250px] flex-shrink-0 text-center">
+              <div className="w-full aspect-video relative mb-4 rounded-lg overflow-hidden">
+                <Media resource={slide.image} fill imgClassName="object-cover" />
+              </div>
+              {slide.description && <p className="text-sm text-muted-foreground">{slide.description}</p>}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default SpectacleCarouselBlock

--- a/src/blocks/SpectacleCarousel/config.ts
+++ b/src/blocks/SpectacleCarousel/config.ts
@@ -1,0 +1,35 @@
+import type { Block } from 'payload'
+
+export const SpectacleCarousel: Block = {
+  slug: 'spectacleCarousel',
+  interfaceName: 'SpectacleCarouselBlock',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+    },
+    {
+      name: 'slides',
+      type: 'array',
+      minRows: 1,
+      fields: [
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+          required: true,
+        },
+        {
+          name: 'description',
+          type: 'textarea',
+        },
+      ],
+    },
+  ],
+  labels: {
+    singular: 'Carrusel de espect\u00e1culos',
+    plural: 'Carruseles de espect\u00e1culos',
+  },
+}
+
+export default SpectacleCarousel

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -23,6 +23,7 @@ import {
   PreviewField,
 } from '@payloadcms/plugin-seo/fields'
 import { StepFlowBlock } from '../../blocks/StepFlowBlock/config'
+import { SpectacleCarousel } from '../../blocks/SpectacleCarousel/config'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
@@ -83,6 +84,7 @@ export const Pages: CollectionConfig<'pages'> = {
                 ImageTextSection,
                 ImageGridHero,
                 ImgFormBlock,
+                SpectacleCarousel,
                 StepFlowBlock,
               ],
               required: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -185,6 +185,7 @@ export interface Page {
         blockName?: string | null;
         blockType: 'imgForm';
       }
+    | SpectacleCarouselBlock
     | StepFlowBlock
   )[];
   meta?: {
@@ -751,6 +752,23 @@ export interface ImageGridHeroBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SpectacleCarouselBlock".
+ */
+export interface SpectacleCarouselBlock {
+  title?: string | null;
+  slides?:
+    | {
+        image: number | Media;
+        description?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'spectacleCarousel';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "StepFlowBlock".
  */
 export interface StepFlowBlock {
@@ -1053,6 +1071,7 @@ export interface PagesSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+        spectacleCarousel?: T | SpectacleCarouselBlockSelect<T>;
         stepFlow?: T | StepFlowBlockSelect<T>;
       };
   meta?:
@@ -1195,6 +1214,22 @@ export interface ImageGridHeroBlockSelect<T extends boolean = true> {
               label?: T;
               appearance?: T;
             };
+        id?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "SpectacleCarouselBlock_select".
+ */
+export interface SpectacleCarouselBlockSelect<T extends boolean = true> {
+  title?: T;
+  slides?:
+    | T
+    | {
+        image?: T;
+        description?: T;
         id?: T;
       };
   id?: T;


### PR DESCRIPTION
## Summary
- add `SpectacleCarousel` block with a title and slide array
- render the new block in the frontend and allow it on pages
- regenerate Payload types

## Testing
- `pnpm lint`
- `pnpm generate:types`

------
https://chatgpt.com/codex/tasks/task_e_684ff70fe8a08331ae0970bbee633dff